### PR TITLE
Expand protease functionality

### DIFF
--- a/rustyms/src/align/mass_alignment.rs
+++ b/rustyms/src/align/mass_alignment.rs
@@ -299,7 +299,7 @@ fn calculate_masses<const STEPS: u16>(
                 .iter()
                 .map(|p| {
                     p.formulas_all(
-                        &[sequence],
+                        &[],
                         &[],
                         &mut Vec::new(),
                         false,

--- a/rustyms/src/aminoacid/aminoacid.rs
+++ b/rustyms/src/aminoacid/aminoacid.rs
@@ -369,6 +369,35 @@ impl AminoAcid {
         Self::Valine,
     ];
 
+    /// All amino acids (including I/L/J/B/Z but excluding X)
+    pub const ALL_AMINO_ACIDS: &'static [Self] = &[
+        Self::Alanine,
+        Self::AmbiguousAsparagine,
+        Self::AmbiguousGlutamine,
+        Self::AmbiguousLeucine,
+        Self::Arginine,
+        Self::Asparagine,
+        Self::AsparticAcid,
+        Self::Cysteine,
+        Self::GlutamicAcid,
+        Self::Glutamine,
+        Self::Glycine,
+        Self::Histidine,
+        Self::Isoleucine,
+        Self::Leucine,
+        Self::Lysine,
+        Self::Methionine,
+        Self::Phenylalanine,
+        Self::Proline,
+        Self::Pyrrolysine,
+        Self::Selenocysteine,
+        Self::Serine,
+        Self::Threonine,
+        Self::Tryptophan,
+        Self::Tyrosine,
+        Self::Valine,
+    ];
+
     // TODO: generalise over used storage type, so using molecularformula, monoisotopic mass, or average mass, also make sure that AAs can return these numbers in a const fashion
     #[expect(clippy::too_many_lines, clippy::too_many_arguments)]
     pub(crate) fn fragments(

--- a/rustyms/src/peptidoform/peptidoform.rs
+++ b/rustyms/src/peptidoform/peptidoform.rs
@@ -1511,7 +1511,12 @@ impl<Complexity: AtMax<Linear>> Peptidoform<Complexity> {
     }
 
     /// Digest this sequence with the given protease and the given maximal number of missed cleavages.
-    pub fn digest(&self, protease: &Protease, max_missed_cleavages: usize) -> Vec<Self> {
+    pub fn digest(
+        &self,
+        protease: &Protease,
+        max_missed_cleavages: usize,
+        size_range: impl RangeBounds<usize>,
+    ) -> Vec<Self> {
         let mut sites = vec![0];
         sites.extend_from_slice(&protease.match_locations(&self.sequence));
         sites.push(self.len());
@@ -1520,7 +1525,9 @@ impl<Complexity: AtMax<Linear>> Peptidoform<Complexity> {
 
         for (index, start) in sites.iter().enumerate() {
             for end in sites.iter().skip(index + 1).take(max_missed_cleavages + 1) {
-                result.push(self.sub_peptide((*start)..*end));
+                if size_range.contains(&(end - start)) {
+                    result.push(self.sub_peptide((*start)..*end));
+                }
             }
         }
         result

--- a/rustyms/src/peptidoform/peptidoform.rs
+++ b/rustyms/src/peptidoform/peptidoform.rs
@@ -431,10 +431,7 @@ impl<Complexity> Peptidoform<Complexity> {
                     if let Modification::Ambiguous { .. } = f {
                         acc
                     } else {
-                        let attachment = all_peptides[peptidoform_index]
-                            .sequence
-                            .first()
-                            .map(|s| s.aminoacid.aminoacid());
+                        let attachment = self.sequence.first().map(|s| s.aminoacid.aminoacid());
                         let (formula, specific, _seen) = f.formula_inner(
                             all_peptides,
                             visited_peptides,
@@ -1522,7 +1519,7 @@ impl<Complexity: AtMax<Linear>> Peptidoform<Complexity> {
         let mut result = Vec::new();
 
         for (index, start) in sites.iter().enumerate() {
-            for end in sites.iter().skip(index).take(max_missed_cleavages + 1) {
+            for end in sites.iter().skip(index + 1).take(max_missed_cleavages + 1) {
                 result.push(self.sub_peptide((*start)..*end));
             }
         }

--- a/rustyms/src/protease.rs
+++ b/rustyms/src/protease.rs
@@ -118,18 +118,6 @@ pub mod known_proteases {
         ])
     });
 
-    /// Elastase cuts after Alanine (A), Glycine (G), Serine (S), Valine (V), Isoleucine (I), Leucine (L)
-    pub static ELASTASE: LazyLock<Protease> = LazyLock::new(|| {
-        Protease::c_terminal_of(vec![
-            AminoAcid::Alanine,
-            AminoAcid::Glycine,
-            AminoAcid::Serine,
-            AminoAcid::Valine,
-            AminoAcid::Isoleucine,
-            AminoAcid::Leucine,
-        ])
-    });
-
     /// `AspN` cuts before Aspartic acid (D)
     pub static ASPN: LazyLock<Protease> =
         LazyLock::new(|| Protease::n_terminal_of(vec![AminoAcid::AsparticAcid]));

--- a/rustyms/src/protease.rs
+++ b/rustyms/src/protease.rs
@@ -1,4 +1,7 @@
+use std::sync::LazyLock;
+
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 use crate::{AminoAcid, SequenceElement};
 
@@ -6,50 +9,67 @@ use crate::{AminoAcid, SequenceElement};
 /// Each position is identified by an option, a none means that there is no specificity at this position. If there is
 /// a specificity at a certain position any amino acid that is contained in the set is allowed (see
 /// [`crate::CheckedAminoAcid::canonical_identical`]).
+///
+/// #TODO: Add the possibility to define the effiency of amino acids or certain motifs
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Protease {
     /// The amino acids n terminal of the cut site.
-    pub n_term: Vec<Option<Vec<AminoAcid>>>,
+    pub before: Vec<Option<Vec<AminoAcid>>>,
     /// The amino acids c terminal of the cut site.
-    pub c_term: Vec<Option<Vec<AminoAcid>>>,
+    pub after: Vec<Option<Vec<AminoAcid>>>,
 }
 
 impl Protease {
     /// Define a simple protease that cuts exactly between the specified sequences.
-    pub fn new(n_term: &[AminoAcid], c_term: &[AminoAcid]) -> Self {
+    pub fn new(n_term: Vec<AminoAcid>, c_term: Vec<AminoAcid>) -> Self {
         Self {
-            n_term: n_term.iter().map(|aa| Some(vec![*aa])).collect_vec(),
-            c_term: c_term.iter().map(|aa| Some(vec![*aa])).collect_vec(),
-        }
-    }
-
-    /// Define a protease that cuts on the n terminal side of the provided amino acids.
-    pub fn n_terminal_of(residues: &[AminoAcid]) -> Self {
-        Self {
-            n_term: vec![Some(residues.to_vec())],
-            c_term: Vec::new(),
+            before: vec![Some(n_term)],
+            after: vec![Some(c_term)],
         }
     }
 
     /// Define a protease that cuts on the c terminal side of the provided amino acids.
-    pub fn c_terminal_of(residues: &[AminoAcid]) -> Self {
+    pub fn c_terminal_of(residues: Vec<AminoAcid>) -> Self {
         Self {
-            c_term: vec![Some(residues.to_vec())],
-            n_term: Vec::new(),
+            before: vec![Some(residues)],
+            after: Vec::new(),
         }
     }
 
+    /// Define a protease that cuts on the n terminal side of the provided amino acids.
+    pub fn n_terminal_of(residues: Vec<AminoAcid>) -> Self {
+        Self {
+            before: Vec::new(),
+            after: vec![Some(residues)],
+        }
+    }
+
+    /// Helper function to get a list of all amino acids except the ones given
+    pub fn get_exclusive(exclude: &[AminoAcid]) -> Vec<AminoAcid> {
+        AminoAcid::ALL_AMINO_ACIDS
+            .iter()
+            .copied()
+            .filter(|aa| !exclude.contains(aa))
+            .collect_vec()
+    }
+
     /// All locations in the given sequence where this protease could cut
+    /// Note if a cutsite is "after" the last element in the sequence, it will not rapport that, only the cutsites inside the sequence
     pub fn match_locations<T>(&self, sequence: &[SequenceElement<T>]) -> Vec<usize> {
-        (self.n_term.len()..sequence.len() - self.c_term.len())
-            .filter(|i| self.matches_at(&sequence[i - self.n_term.len()..i + self.c_term.len()]))
+        let upper = sequence
+            .len()
+            .saturating_sub(self.after.len())
+            .min(sequence.len().saturating_sub(1));
+        (self.before.len()..=upper)
+            .filter(|i| self.matches_at(&sequence[i - self.before.len()..i + self.after.len()]))
             .collect_vec()
     }
 
     fn matches_at<T>(&self, slice: &[SequenceElement<T>]) -> bool {
-        debug_assert!(slice.len() == self.n_term.len() + self.c_term.len());
+        debug_assert!(slice.len() == self.before.len() + self.after.len());
         'positions: for (actual, pattern) in slice
             .iter()
-            .zip(self.n_term.iter().chain(self.c_term.iter()))
+            .zip(self.before.iter().chain(self.after.iter()))
         {
             if let Some(pattern) = pattern {
                 for option in pattern {
@@ -61,5 +81,328 @@ impl Protease {
             }
         }
         true
+    }
+}
+
+/// Some well known and widely used proteases
+pub mod known_proteases {
+    use super::*;
+
+    /// `Trypsin` cuts after Lysine (K) or Arginine (R), unless followed by Proline (P)
+    pub static TRYPSIN: LazyLock<Protease> = LazyLock::new(|| {
+        Protease::new(
+            vec![AminoAcid::Lysine, AminoAcid::Arginine],
+            Protease::get_exclusive(&[AminoAcid::Proline]),
+        )
+    });
+
+    /// `Chymotrypsin` cuts after Phenylalanine (F), Tryptophan (W), Tyrosine (Y), unless followed by Proline (P)
+    pub static CHYMOTRYPSIN: LazyLock<Protease> = LazyLock::new(|| {
+        Protease::new(
+            vec![
+                AminoAcid::Phenylalanine,
+                AminoAcid::Tryptophan,
+                AminoAcid::Tyrosine,
+            ],
+            Protease::get_exclusive(&[AminoAcid::Proline]),
+        )
+    });
+
+    /// `Pepsin` (pH > 2) cuts after Phenylalanine (F), Tryptophan (W), Tyrosine (Y), Leucine (L)
+    pub static PEPSIN: LazyLock<Protease> = LazyLock::new(|| {
+        Protease::c_terminal_of(vec![
+            AminoAcid::Phenylalanine,
+            AminoAcid::Tryptophan,
+            AminoAcid::Tyrosine,
+            AminoAcid::Leucine,
+        ])
+    });
+
+    /// Elastase cuts after Alanine (A), Glycine (G), Serine (S), Valine (V), Isoleucine (I), Leucine (L)
+    pub static ELASTASE: LazyLock<Protease> = LazyLock::new(|| {
+        Protease::c_terminal_of(vec![
+            AminoAcid::Alanine,
+            AminoAcid::Glycine,
+            AminoAcid::Serine,
+            AminoAcid::Valine,
+            AminoAcid::Isoleucine,
+            AminoAcid::Leucine,
+        ])
+    });
+
+    /// `AspN` cuts before Aspartic acid (D)
+    pub static ASPN: LazyLock<Protease> =
+        LazyLock::new(|| Protease::n_terminal_of(vec![AminoAcid::AsparticAcid]));
+
+    /// `GluC` cuts after Glutamic acid (E)
+    pub static GLUC: LazyLock<Protease> =
+        LazyLock::new(|| Protease::c_terminal_of(vec![AminoAcid::GlutamicAcid]));
+
+    /// `LysC` cuts after Lysine (K)
+    pub static LYSC: LazyLock<Protease> =
+        LazyLock::new(|| Protease::c_terminal_of(vec![AminoAcid::Lysine]));
+
+    /// `ArgC` cuts after Arginine (R)
+    pub static ARGC: LazyLock<Protease> =
+        LazyLock::new(|| Protease::c_terminal_of(vec![AminoAcid::Arginine]));
+}
+
+#[cfg(test)]
+#[allow(clippy::missing_panics_doc)]
+mod tests {
+    use crate::{Linear, Peptidoform};
+
+    use super::*;
+
+    pub struct ProteaseTestCase {
+        pub sequence: Peptidoform<Linear>,
+        pub expected_cut_sites: Vec<usize>,
+        pub expected_peptides: Vec<Peptidoform<Linear>>,
+    }
+
+    /// Generic test function for all proteases
+    pub fn test_protease(protease: &Protease, test_case: &ProteaseTestCase) {
+        // Test cut sites
+        let cut_sites = protease.match_locations(test_case.sequence.sequence());
+
+        assert_eq!(
+            cut_sites, test_case.expected_cut_sites,
+            "Incorrect cut sites: found '{cut_sites:?}' expected '{:?}'",
+            test_case.expected_cut_sites
+        );
+
+        // Test peptides
+        let peptides = test_case.sequence.digest(protease, 0);
+
+        if peptides.len() != test_case.expected_peptides.len() {
+            for peptide in &peptides {
+                println!("{peptide}");
+            }
+            panic!("Incorrect number of peptides")
+        }
+
+        for (i, peptide) in peptides.iter().enumerate() {
+            assert_eq!(
+                peptide, &test_case.expected_peptides[i],
+                "Peptides don't match: found '{peptide}' expected '{}'",
+                test_case.expected_peptides[i]
+            );
+        }
+    }
+
+    fn str_to_peptidoform(str_peptide: &str) -> Peptidoform<Linear> {
+        Peptidoform::pro_forma(str_peptide, None)
+            .unwrap()
+            .into_linear()
+            .unwrap()
+    }
+
+    #[test]
+    fn trypsin() {
+        let test_cases = vec![
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("AKRPGKR"),
+                expected_cut_sites: vec![2, 6],
+                expected_peptides: vec![
+                    str_to_peptidoform("AK"),
+                    str_to_peptidoform("RPGK"),
+                    str_to_peptidoform("R"),
+                ],
+            },
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("ARAKGCVLRPKDGR"),
+                expected_cut_sites: vec![2, 4, 11],
+                expected_peptides: vec![
+                    str_to_peptidoform("AR"),
+                    str_to_peptidoform("AK"),
+                    str_to_peptidoform("GCVLRPK"),
+                    str_to_peptidoform("DGR"),
+                ],
+            },
+        ];
+
+        for test_case in test_cases {
+            test_protease(&known_proteases::TRYPSIN, &test_case);
+        }
+    }
+
+    #[test]
+    fn chymotrypsin() {
+        let test_cases = vec![
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("AFWYPLGF"),
+                expected_cut_sites: vec![2, 3],
+                expected_peptides: vec![
+                    str_to_peptidoform("AF"),
+                    str_to_peptidoform("W"),
+                    str_to_peptidoform("YPLGF"),
+                ],
+            },
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("AVFUDGWTYPMSR"),
+                expected_cut_sites: vec![3, 7],
+                expected_peptides: vec![
+                    str_to_peptidoform("AVF"),
+                    str_to_peptidoform("UDGW"),
+                    str_to_peptidoform("TYPMSR"),
+                ],
+            },
+        ];
+
+        for test_case in test_cases {
+            test_protease(&known_proteases::CHYMOTRYPSIN, &test_case);
+        }
+    }
+
+    #[test]
+    fn pepsin() {
+        let test_cases = vec![
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("AACVFLPAKLURF"),
+                expected_cut_sites: vec![5, 6, 10],
+                expected_peptides: vec![
+                    str_to_peptidoform("AACVF"),
+                    str_to_peptidoform("L"),
+                    str_to_peptidoform("PAKL"),
+                    str_to_peptidoform("URF"),
+                ],
+            },
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("GFLPKDLVMSRG"),
+                expected_cut_sites: vec![2, 3, 7],
+                expected_peptides: vec![
+                    str_to_peptidoform("GF"),
+                    str_to_peptidoform("L"),
+                    str_to_peptidoform("PKDL"),
+                    str_to_peptidoform("VMSRG"),
+                ],
+            },
+        ];
+
+        for test_case in test_cases {
+            test_protease(&known_proteases::PEPSIN, &test_case);
+        }
+    }
+
+    #[test]
+    fn elastase() {
+        let test_cases = vec![
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("FASGVPRKT"),
+                expected_cut_sites: vec![2, 3, 4, 5],
+                expected_peptides: vec![
+                    str_to_peptidoform("FA"),
+                    str_to_peptidoform("S"),
+                    str_to_peptidoform("G"),
+                    str_to_peptidoform("V"),
+                    str_to_peptidoform("PRKT"),
+                ],
+            },
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("PGAVSLFTGK"),
+                expected_cut_sites: vec![2, 3, 4, 5, 6, 9],
+                expected_peptides: vec![
+                    str_to_peptidoform("PG"),
+                    str_to_peptidoform("A"),
+                    str_to_peptidoform("V"),
+                    str_to_peptidoform("S"),
+                    str_to_peptidoform("L"),
+                    str_to_peptidoform("FTG"),
+                    str_to_peptidoform("K"),
+                ],
+            },
+        ];
+
+        for test_case in test_cases {
+            test_protease(&known_proteases::ELASTASE, &test_case);
+        }
+    }
+
+    #[test]
+    fn aspn() {
+        let test_cases = vec![
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("FARDKPGLFD"),
+                expected_cut_sites: vec![3, 9],
+                expected_peptides: vec![
+                    str_to_peptidoform("FAR"),
+                    str_to_peptidoform("DKPGLF"),
+                    str_to_peptidoform("D"),
+                ],
+            },
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("PFKDLTMSR"),
+                expected_cut_sites: vec![3],
+                expected_peptides: vec![str_to_peptidoform("PFK"), str_to_peptidoform("DLTMSR")],
+            },
+        ];
+
+        for test_case in test_cases {
+            test_protease(&known_proteases::ASPN, &test_case);
+        }
+    }
+
+    #[test]
+    fn gluc() {
+        let test_cases = vec![
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("FAREDKPGLF"),
+                expected_cut_sites: vec![4],
+                expected_peptides: vec![str_to_peptidoform("FARE"), str_to_peptidoform("DKPGLF")],
+            },
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("PFKELGTMSR"),
+                expected_cut_sites: vec![4],
+                expected_peptides: vec![str_to_peptidoform("PFKE"), str_to_peptidoform("LGTMSR")],
+            },
+        ];
+
+        for test_case in test_cases {
+            test_protease(&known_proteases::GLUC, &test_case);
+        }
+    }
+
+    #[test]
+    fn lysc() {
+        let test_cases = vec![
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("FARKDPGLF"),
+                expected_cut_sites: vec![4],
+                expected_peptides: vec![str_to_peptidoform("FARK"), str_to_peptidoform("DPGLF")],
+            },
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("PFKDLTKMSR"),
+                expected_cut_sites: vec![3, 7],
+                expected_peptides: vec![
+                    str_to_peptidoform("PFK"),
+                    str_to_peptidoform("DLTK"),
+                    str_to_peptidoform("MSR"),
+                ],
+            },
+        ];
+
+        for test_case in test_cases {
+            test_protease(&known_proteases::LYSC, &test_case);
+        }
+    }
+
+    #[test]
+    fn argc() {
+        let test_cases = vec![
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("FARKDPGLF"),
+                expected_cut_sites: vec![3],
+                expected_peptides: vec![str_to_peptidoform("FAR"), str_to_peptidoform("KDPGLF")],
+            },
+            ProteaseTestCase {
+                sequence: str_to_peptidoform("PFKDLRTMSR"),
+                expected_cut_sites: vec![6],
+                expected_peptides: vec![str_to_peptidoform("PFKDLR"), str_to_peptidoform("TMSR")],
+            },
+        ];
+
+        for test_case in test_cases {
+            test_protease(&known_proteases::ARGC, &test_case);
+        }
     }
 }


### PR DESCRIPTION
Before merging I'd like to double check all the protease definitions (and add references). Furthermore I'd also like to look into the probability of a given enzyme cutting a valid cutsite because some sites are cut more often than others (note that this behaviour is reflected in the missed cleavages). I also want to add a (few) test(s) for the missed cleavage parameter in the digest function. Lastly I intend to add docs-test with some examples.