### PR TITLE
Alignment from path

### DIFF
--- a/rustyms/src/align/alignment.rs
+++ b/rustyms/src/align/alignment.rs
@@ -16,9 +16,8 @@ use crate::{
     annotation::model::GlycanModel,
     chemistry::MolecularFormula,
     helper_functions::next_num,
-    prelude::HasPeptidoformImpl,
     quantities::Multi,
-    sequence::{AtMax, HasPeptidoform, Linear, SequencePosition, SimpleLinear},
+    sequence::{HasPeptidoform, Linear, SequencePosition, SimpleLinear},
     system::{Mass, Ratio},
 };
 
@@ -113,10 +112,8 @@ impl<A: Eq, B: Eq> Ord for Alignment<A, B> {
 
 impl<'lifetime, A, B> Alignment<&'lifetime A, &'lifetime B>
 where
-    A: HasPeptidoformImpl,
-    A::Complexity: AtMax<SimpleLinear>,
-    B: HasPeptidoformImpl,
-    B::Complexity: AtMax<SimpleLinear>,
+    A: HasPeptidoform<SimpleLinear>,
+    B: HasPeptidoform<SimpleLinear>,
 {
     /// Recreate an alignment from a path, the path is [`Self::short`].
     #[expect(clippy::missing_panics_doc, clippy::too_many_arguments)]
@@ -206,7 +203,7 @@ where
                 MatchType::FullIdentity | MatchType::IdentityMassMismatch | MatchType::Mismatch => {
                     (0..a)
                         .map(|_| {
-                            let mass_a = seq_a.peptidoform()[index_a]
+                            let mass_a = seq_a.cast_peptidoform()[index_a]
                                 .formulas_all(
                                     &[],
                                     &[],
@@ -221,7 +218,7 @@ where
                                 .iter()
                                 .map(MolecularFormula::monoisotopic_mass)
                                 .collect();
-                            let mass_b = seq_b.peptidoform()[index_b]
+                            let mass_b = seq_b.cast_peptidoform()[index_b]
                                 .formulas_all(
                                     &[],
                                     &[],
@@ -237,8 +234,8 @@ where
                                 .map(MolecularFormula::monoisotopic_mass)
                                 .collect();
                             let piece = score_pair(
-                                (&seq_a.peptidoform()[index_a], &mass_a),
-                                (&seq_b.peptidoform()[index_b], &mass_b),
+                                (&seq_a.cast_peptidoform()[index_a], &mass_a),
+                                (&seq_b.cast_peptidoform()[index_b], &mass_b),
                                 scoring,
                                 score,
                             );
@@ -287,8 +284,8 @@ where
             seq_a,
             seq_b,
             score: determine_final_score(
-                seq_a.peptidoform(),
-                seq_b.peptidoform(),
+                seq_a.cast_peptidoform(),
+                seq_b.cast_peptidoform(),
                 start_a,
                 start_b,
                 &path,

--- a/rustyms/src/sequence/peptidoform/parse_sloppy.rs
+++ b/rustyms/src/sequence/peptidoform/parse_sloppy.rs
@@ -61,13 +61,13 @@ impl Peptidoform<SemiAmbiguous> {
         let chars: &[u8] = line[location.clone()].as_bytes();
         peptide
             .sequence_mut()
-            .reserve(chars.iter().map(u8::is_ascii_uppercase).count());
+            .reserve(chars.iter().map(u8::is_ascii_uppercase).count()); // Reserve approximately the right length for the vector, this will overestimate in some cases but not by a lot
         let mut index = 0;
 
         while index < chars.len() {
             match chars[index] {
                 b'n' if parameters.ignore_prefix_lowercase_n && index == 0 => index += 1, //ignore
-                b',' | b'_' | b'-' => index += 1,
+                b',' | b'_' | b'-' => index += 1,                                         //ignore
                 b'[' | b'(' => {
                     let (open, close) = if chars[index] == b'[' {
                         (b'[', b']')

--- a/rustyms/src/sequence/peptidoform/parse_sloppy.rs
+++ b/rustyms/src/sequence/peptidoform/parse_sloppy.rs
@@ -67,7 +67,7 @@ impl Peptidoform<SemiAmbiguous> {
         while index < chars.len() {
             match chars[index] {
                 b'n' if parameters.ignore_prefix_lowercase_n && index == 0 => index += 1, //ignore
-                b',' | b'_' | b'-' => index += 1,                                         //ignore
+                b',' | b'_' => index += 1,                                                //ignore
                 b'[' | b'(' => {
                     let (open, close) = if chars[index] == b'[' {
                         (b'[', b']')


### PR DESCRIPTION
For a project of mine I needed to be able to create alignments given a path and some other parameters. This was already possible in mzcore but I needed generic types and the older version only allowed Peptidoforms of different complexities but I needed to be able to use &FastaData for example because of my downstream analyses. So this small update makes sure that's possible.

Next I also added "-" at rustyms/src/sequence/peptidoform/parse_sloppy.rs:70 because it wasn't parsing some of my modifications correctly. Specifically it wasn't able to parse peptides like these: `[U:Carbamyl][-17.027]-EGEEEK` because it got stuck on the - between the two n-term modifications and the actual peptide. This small change makes sure it ignore the dash and can thus parse it correctly. Maybe good to add a test case somewhere?