### PR TITLE
Handle empty ProForma formulas

### DIFF
--- a/mzcore/src/chemistry/formula/formula.rs
+++ b/mzcore/src/chemistry/formula/formula.rs
@@ -352,5 +352,10 @@ mod tests {
             MolecularFormula::pro_forma::<false, true>("(empty)"),
             MolecularFormula::pro_forma::<false, true>("H0")
         );
+        assert_eq!(
+            MolecularFormula::pro_forma::<false, true>(""),
+            MolecularFormula::pro_forma::<false, true>("H0")
+        );
+        assert!(MolecularFormula::pro_forma::<false, false>("").is_err());
     }
 }

--- a/mzcore/src/chemistry/formula/pro_forma.rs
+++ b/mzcore/src/chemistry/formula/pro_forma.rs
@@ -75,7 +75,7 @@ impl MolecularFormula {
         range: impl RangeBounds<usize>,
     ) -> Result<Self, BoxedError<'a, BasicKind>> {
         let (mut index, end) = range.bounds(value.len().saturating_sub(1));
-        if index > end || &value[index..=end] == "(empty)" {
+        if value.is_empty() || index > end || value.get(index..=end) == Some("(empty)") {
             return if ALLOW_EMPTY {
                 Ok(Self::default())
             } else {


### PR DESCRIPTION
This PR fixes an existing mzcore ProForma molecular formula parser panic for empty input.

 Previously, `MolecularFormula::pro_forma::<_, true>("")` could attempt an inclusive slice on an empty string and panic, even though empty formulas are documented as valid when  `ALLOW_EMPTY` is enabled.

Changes:

  - Detect empty input before slicing the requested formula range.
  - Preserve existing behavior:
      - empty formulas return `Ok(default)` when `ALLOW_EMPTY = true`
      - empty formulas return an error when `ALLOW_EMPTY = false`

  - Add regression coverage for both accepted and rejected empty input.

 Validated xith:

 ```
CARGO_INCREMENTAL=0 cargo test -p mzcore --doc MolecularFormula::pro_forma --no-fail-fast
CARGO_INCREMENTAL=0 cargo test -p mzcore pro_forma_empty --lib --no-fail-fast
 ```
 
Both pass.